### PR TITLE
Feature GitHub repoutils

### DIFF
--- a/server/model/repo.py
+++ b/server/model/repo.py
@@ -34,8 +34,13 @@ def create_repo_from_github(
             db.session.flush()
 
             current_repo = new_repo
-
-        app.logger.debug(f"Repo {current_repo.id} created")
+            app.logger.debug(f"Repo {current_repo.id} created")
+        else:
+            # 更新 repo 信息
+            # 暂不支持更新 repo 名称
+            current_repo.description = repo["description"]
+            db.session.add(current_repo)
+            db.session.flush()
 
         # 拉取仓库成员，创建 RepoUser
         repo_users = github_app.get_repo_collaborators(repo["name"], org_name)

--- a/server/utils/github/bot.py
+++ b/server/utils/github/bot.py
@@ -24,8 +24,13 @@ class BaseGitHubApp:
         self._user_token: str = None
 
     def base_github_rest_api(
-        self, url: str, method: str = "GET", auth_type: str = "jwt", json: dict = None
-    ) -> dict | list | None:
+        self,
+        url: str,
+        method: str = "GET",
+        auth_type: str = "jwt",
+        json: dict = None,
+        raw: bool = False,
+    ) -> dict | list | httpx.Response | None:
         """Base GitHub REST API.
 
         Args:
@@ -62,6 +67,8 @@ class BaseGitHubApp:
                 },
                 json=json,
             )
+            if raw:
+                return response
             return response.json()
 
     @property

--- a/server/utils/github/repo.py
+++ b/server/utils/github/repo.py
@@ -173,3 +173,39 @@ class GitHubAppRepo(BaseGitHubApp):
             "user_token",
             json={"names": topics},
         )
+
+    def add_repo_collaborator(
+        self,
+        repo_onwer: str,
+        repo_name: str,
+        username: str,
+        permission: str = "pull",
+    ) -> dict | None:
+        """Add repo collaborator
+
+        Note that username should be included in the organization.
+        The GitHub API **DO** supports adding a collaborator who
+        is not a member of the organization, but here we restrict
+        members only.
+
+        Args:
+            repo_onwer (str): The repo owner.
+            repo_name (str): The repo name.
+            username (str): The username.
+            permission (str): The permission. Defaults to "pull".
+
+        Returns:
+            dict: The repo info
+        """
+        res = self.base_github_rest_api(
+            f"https://api.github.com/repos/{repo_onwer}/{repo_name}/collaborators/{username}",
+            "PUT",
+            "user_token",
+            json={"permission": permission},
+            raw=True,
+        )
+
+        if res.status_code == 204:
+            return {"status": "success"}
+        else:
+            return {"status": "failed", "message": res.json()["message"]}

--- a/server/utils/github/repo.py
+++ b/server/utils/github/repo.py
@@ -59,63 +59,6 @@ class GitHubAppRepo(BaseGitHubApp):
             auth_type="install_token",
         )
 
-    def create_issue(
-        self,
-        repo_onwer: str,
-        repo_name: str,
-        title: str,
-        body: str,
-        assignees: list[str],
-        labels: list[str],
-    ) -> dict | None:
-        """Create issue
-
-        Args:
-            repo_onwer (str): The repo owner.
-            repo_name (str): The repo name.
-            title (str): The issue title.
-            body (str): The issue body.
-            assignees (list[str]): The issue assignees.
-            labels (list[str]): The issue labels.
-
-        Returns:
-            dict: The issue info.
-        """
-
-        return self.base_github_rest_api(
-            f"https://api.github.com/repos/{repo_onwer}/{repo_name}/issues",
-            "POST",
-            "user_token",
-            json={
-                "title": title,
-                "body": body,
-                "assignees": assignees,
-                "labels": labels,
-            },
-        )
-
-    def create_issue_comment(
-        self, repo_onwer: str, repo_name: str, issue_number: int, body: str
-    ) -> dict | None:
-        """Create issue comment
-
-        Args:
-            repo_onwer (str): The repo owner.
-            repo_name (str): The repo name.
-            issue_number (int): The issue number.
-            body (str): The comment body.
-
-        Returns:
-            dict: The comment info.
-        """
-
-        return self.base_github_rest_api(
-            f"https://api.github.com/repos/{repo_onwer}/{repo_name}/issues/{issue_number}/comments",
-            "POST",
-            "user_token",
-            json={"body": body},
-        )
-
     def update_repo(
         self,
         repo_onwer: str,
@@ -209,3 +152,96 @@ class GitHubAppRepo(BaseGitHubApp):
             return {"status": "success"}
         else:
             return {"status": "failed", "message": res.json()["message"]}
+
+    def create_issue(
+        self,
+        repo_onwer: str,
+        repo_name: str,
+        title: str,
+        body: str,
+        assignees: list[str] = None,
+        labels: list[str] = None,
+    ) -> dict | None:
+        """Create issue
+
+        Args:
+            repo_onwer (str): The repo owner.
+            repo_name (str): The repo name.
+            title (str): The issue title.
+            body (str): The issue body.
+            assignees (list[str]): The issue assignees.
+            labels (list[str]): The issue labels.
+
+        Returns:
+            dict: The issue info.
+        """
+
+        return self.base_github_rest_api(
+            f"https://api.github.com/repos/{repo_onwer}/{repo_name}/issues",
+            "POST",
+            "user_token",
+            json={
+                "title": title,
+                "body": body,
+                "assignees": assignees,
+                "labels": labels,
+            },
+        )
+
+    def create_issue_comment(
+        self, repo_onwer: str, repo_name: str, issue_number: int, body: str
+    ) -> dict | None:
+        """Create issue comment
+
+        Args:
+            repo_onwer (str): The repo owner.
+            repo_name (str): The repo name.
+            issue_number (int): The issue number.
+            body (str): The comment body.
+
+        Returns:
+            dict: The comment info.
+        """
+
+        return self.base_github_rest_api(
+            f"https://api.github.com/repos/{repo_onwer}/{repo_name}/issues/{issue_number}/comments",
+            "POST",
+            "user_token",
+            json={"body": body},
+        )
+
+    def update_issue(
+        self,
+        repo_onwer: str,
+        repo_name: str,
+        issue_number: int,
+        title: str = None,
+        body: str = None,
+        state: str = None,
+        state_reason: str = None,
+        assignees: list[str] = None,
+        labels: list[str] = None,
+    ) -> dict | None:
+        """Reopen issue
+
+        Args:
+            repo_onwer (str): The repo owner.
+            repo_name (str): The repo name.
+            issue_number (int): The issue number.
+
+        Returns:
+            dict: The issue info.
+        """
+
+        json = {}
+        for arg in [title, body, state, state_reason, assignees, labels]:
+            if arg is None:
+                continue
+            json.update({arg.__name__: arg})
+
+        return self.base_github_rest_api(
+            f"https://api.github.com/repos/{repo_onwer}/{repo_name}/issues/{issue_number}",
+            "PATCH",
+            "user_token",
+            json=json,
+        )

--- a/server/utils/github/repo.py
+++ b/server/utils/github/repo.py
@@ -115,3 +115,61 @@ class GitHubAppRepo(BaseGitHubApp):
             "user_token",
             json={"body": body},
         )
+
+    def update_repo(
+        self,
+        repo_onwer: str,
+        repo_name: str,
+        description: str = None,
+        homepage: str = None,
+        private: bool = None,
+        archived: bool = None,
+    ) -> dict | None:
+        """Update GitHub repo Info
+
+        Args:
+            repo_onwer (str): The repo owner.
+            repo_name (str): The repo name.
+            description (str): The repo description.
+            homepage (str): The repo homepage.
+            private (bool): The repo private.
+            archived (bool): The repo archived.
+
+        Returns:
+            dict: The repo info.
+        """
+
+        json = {}
+
+        for arg in [description, homepage, private, archived]:
+            if arg is None:
+                continue
+            json.update({arg.__name__: arg})
+
+        return self.base_github_rest_api(
+            f"https://api.github.com/repos/{repo_onwer}/{repo_name}",
+            "PATCH",
+            "user_token",
+            json=json,
+        )
+
+    def replace_topics(
+        self, repo_onwer: str, repo_name: str, topics: list[str]
+    ) -> dict | None:
+        """Replace topics
+
+        Args:
+            repo_onwer (str): The repo owner.
+            repo_name (str): The repo name.
+            topics (list[str]): The repo topics.
+
+        Returns:
+            dict: The repo info.
+        """
+
+        return self.base_github_rest_api(
+            f"https://api.github.com/repos/{repo_onwer}/{repo_name}/topics",
+            "PUT",
+            "user_token",
+            json={"names": topics},
+        )

--- a/server/utils/user.py
+++ b/server/utils/user.py
@@ -35,7 +35,7 @@ def register(code: str) -> str | None:
 
     new_user_id, _ = create_github_user(
         github_id=github_id,
-        name=user_info.get("name", None),
+        name=user_info.get("login", None),
         email=email,
         avatar=user_info.get("avatar_url", None),
         access_token=access_token,


### PR DESCRIPTION
- 为`base_github_rest_api`添加了`raw: bool`模式以适应多种情况
- 新增三个用于添加了修改仓库 description，homepage，private，archived，修改仓库 topics，添加团队内协作者的 API
- 修复了在 OAuth 时没有正确选择注册者用户名的问题